### PR TITLE
Create option to skip drop chance randomization when randomizing drops

### DIFF
--- a/constants/options.rb
+++ b/constants/options.rb
@@ -12,7 +12,8 @@ OPTIONS = {
   
   randomize_enemies: "Randomizes which non-boss enemies appear where.",
   randomize_bosses: "Randomizes which bosses appear where.",
-  randomize_enemy_drops: "Randomizes the items, souls, and glyphs dropped by non-boss enemies, as well as their drop chances.",
+  randomize_enemy_drops: "Randomizes the items, souls, and glyphs dropped by non-boss enemies.",
+  randomize_enemy_drop_chances: "Randomizes the chance of items, souls and glyps dropped by non-boss enemies.",
   randomize_enemy_stats: "Randomizes enemy attack, defense, HP, EXP given, and other stats.",
   randomize_enemy_anim_speed: "Randomizes the speed at which each enemy's animations play at, which affects their attack speed.",
   randomize_enemy_tolerances: "Randomizes enemy elemental weaknesses and resistances.",

--- a/randomizer.ui
+++ b/randomizer.ui
@@ -225,6 +225,16 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="3">
+            <widget class="QCheckBox" name="randomize_enemy_drop_chances">
+            <property name="text">
+             <string>Enemy Drop Chances</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="2">
            <widget class="QCheckBox" name="randomize_enemy_tolerances">
             <property name="text">
@@ -993,6 +1003,7 @@
   <tabstop>randomize_enemies</tabstop>
   <tabstop>randomize_bosses</tabstop>
   <tabstop>randomize_enemy_drops</tabstop>
+   <tabstop>randomize_enemy_drop_chances</tabstop>
   <tabstop>randomize_enemy_stats</tabstop>
   <tabstop>randomize_enemy_anim_speed</tabstop>
   <tabstop>randomize_enemy_tolerances</tabstop>

--- a/randomizers/drop_randomizer.rb
+++ b/randomizers/drop_randomizer.rb
@@ -64,44 +64,12 @@ module DropRandomizer
         enemy["Item 2"] = 0
       end
       
-      item_1_chance = named_rand_range_weighted(:item_drop_chance_range)
-      item_2_chance = named_rand_range_weighted(:item_drop_chance_range)
-      skill_chance = named_rand_range_weighted(:skill_drop_chance_range)
+      
       
       case GAME
       when "dos"
-        internal_item_chance = (item_1_chance/100.0*1024/3).floor
-        internal_item_chance = 1 if internal_item_chance < 1
-        internal_item_chance = 255 if internal_item_chance > 255
-        enemy["Item Chance"] = internal_item_chance
-        
         enemy["Soul"] = get_unplaced_non_progression_skill() - SKILL_GLOBAL_ID_RANGE.begin
-        
-        internal_soul_chance = (skill_chance/100.0*512).floor
-        internal_soul_chance = 1 if internal_soul_chance < 1
-        internal_soul_chance = 255 if internal_soul_chance > 255
-        enemy["Soul Chance"] = internal_soul_chance
-      when "por"
-        internal_item_1_chance = (item_1_chance*2.56).floor
-        internal_item_1_chance = 1 if internal_item_1_chance < 1
-        internal_item_1_chance = 255 if internal_item_1_chance > 255
-        enemy["Item 1 Chance"] = internal_item_1_chance
-        
-        internal_item_2_chance = (item_2_chance*2.56).floor
-        internal_item_2_chance = 1 if internal_item_2_chance < 1
-        internal_item_2_chance = 255 if internal_item_2_chance > 255
-        enemy["Item 2 Chance"] = internal_item_2_chance
       when "ooe"
-        internal_item_1_chance = item_1_chance
-        internal_item_1_chance = 1 if internal_item_1_chance < 1
-        internal_item_1_chance = 255 if internal_item_1_chance > 255
-        enemy["Item 1 Chance"] = internal_item_1_chance
-        
-        internal_item_2_chance = item_2_chance
-        internal_item_2_chance = 1 if internal_item_2_chance < 1
-        internal_item_2_chance = 255 if internal_item_2_chance > 255
-        enemy["Item 2 Chance"] = internal_item_2_chance
-        
         if enemy["Glyph"] != 0
           # Only give glyph drops to enemies that original had a glyph drop.
           # Other enemies cannot drop a glyph anyway.
@@ -113,17 +81,59 @@ module DropRandomizer
             enemy["Glyph"] = get_unplaced_non_progression_skill() - SKILL_GLOBAL_ID_RANGE.begin + 1
           end
           
+
+        end
+      end
+
+      
+      if options[:randomize_enemy_drop_chances]
+        puts "im random stuff"
+          item_1_chance = named_rand_range_weighted(:item_drop_chance_range)
+          item_2_chance = named_rand_range_weighted(:item_drop_chance_range)
+          skill_chance = named_rand_range_weighted(:skill_drop_chance_range)
+        case GAME
+          
+        when "dos"
+          internal_item_chance = (item_1_chance/100.0*1024/3).floor
+          internal_item_chance = 1 if internal_item_chance < 1
+          internal_item_chance = 255 if internal_item_chance > 255
+          enemy["Item Chance"] = internal_item_chance
+          
+          
+          internal_soul_chance = (skill_chance/100.0*512).floor
+          internal_soul_chance = 1 if internal_soul_chance < 1
+          internal_soul_chance = 255 if internal_soul_chance > 255
+          enemy["Soul Chance"] = internal_soul_chance
+        when "por"
+          internal_item_1_chance = (item_1_chance*2.56).floor
+          internal_item_1_chance = 1 if internal_item_1_chance < 1
+          internal_item_1_chance = 255 if internal_item_1_chance > 255
+          enemy["Item 1 Chance"] = internal_item_1_chance
+          
+          internal_item_2_chance = (item_2_chance*2.56).floor
+          internal_item_2_chance = 1 if internal_item_2_chance < 1
+          internal_item_2_chance = 255 if internal_item_2_chance > 255
+          enemy["Item 2 Chance"] = internal_item_2_chance
+        when "ooe"
+          internal_item_1_chance = item_1_chance
+          internal_item_1_chance = 1 if internal_item_1_chance < 1
+          internal_item_1_chance = 255 if internal_item_1_chance > 255
+          enemy["Item 1 Chance"] = internal_item_1_chance
+          
+          internal_item_2_chance = item_2_chance
+          internal_item_2_chance = 1 if internal_item_2_chance < 1
+          internal_item_2_chance = 255 if internal_item_2_chance > 255
+          enemy["Item 2 Chance"] = internal_item_2_chance
           if enemy["Glyph Chance"] != 100 # Don't set glyph chance if it was originally 100%, because it won't matter for those enemies.
             internal_skill_chance = skill_chance
             internal_skill_chance = 1 if internal_skill_chance < 1
             internal_skill_chance = 255 if internal_skill_chance > 255
             enemy["Glyph Chance"] = internal_skill_chance
           end
+      
         end
       end
-      
-      enemy.write_to_rom()
-    end
+    enemy.write_to_rom()
   end
   
   def remove_all_enemy_drops
@@ -162,4 +172,5 @@ module DropRandomizer
       end
     end
   end
+end
 end


### PR DESCRIPTION
Currently, if you select the randomize drops option, the drop chances will be randomized as well to fit the slider options in difficulty tab. While in a normal randomizer run this allows you to get drops more often, it causes races or special runs like ALL souls to feel off since the rates aren't vanilla.

This fork proposes a small change to UI and code which allows for the randomization of drops without randomizing chances.

I still have to test whether this has an impact on progress drops, and there's a possible change to allow players to randomize drop rates without randomizing drops.